### PR TITLE
Build question generator: 5 types from podcast summaries

### DIFF
--- a/lib/anthropic.ts
+++ b/lib/anthropic.ts
@@ -1,0 +1,9 @@
+import Anthropic from "@anthropic-ai/sdk";
+
+const apiKey = process.env.ANTHROPIC_API_KEY;
+
+if (!apiKey) {
+  console.warn("ANTHROPIC_API_KEY not set — AI features will not work");
+}
+
+export const anthropic = new Anthropic({ apiKey: apiKey ?? "" });

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -1,18 +1,167 @@
-/**
- * Question generation from podcast summaries using Anthropic SDK.
- */
+import { anthropic } from "./anthropic";
+import type { Episode } from "./corpus";
 
-export interface Question {
-  id: string;
+export type QuestionType =
+  | "factual_recall"
+  | "speaker_attribution"
+  | "trend_identification"
+  | "prediction"
+  | "connect_the_dots";
+
+export type QuestionFormat = "multiple_choice" | "open";
+
+export interface GeneratedQuestion {
+  type: QuestionType;
+  format: QuestionFormat;
   text: string;
+  options: string[] | null;
+  correct_answer: string;
+  model_answer: string | null;
+  scoring_rubric: string | null;
   topic: string;
-  sourceEpisode: string;
+  source_quote: string | null;
+  episode_id: string;
+  second_episode_id: string | null;
 }
 
-export async function generateQuestions(
-  _topic: string,
-  _count: number = 5,
-): Promise<Question[]> {
-  // TODO: Use Anthropic SDK to generate questions from corpus summaries
-  return [];
+const QUESTION_TYPE_CONFIG: Record<
+  QuestionType,
+  { format: QuestionFormat; description: string }
+> = {
+  factual_recall: {
+    format: "multiple_choice",
+    description:
+      "A factual recall question about a specific detail from the episode. Include 4 options (A-D) with exactly one correct answer.",
+  },
+  speaker_attribution: {
+    format: "multiple_choice",
+    description:
+      "A question asking which podcast or episode is associated with a specific insight or quote. Include 4 options (A-D) with exactly one correct answer.",
+  },
+  trend_identification: {
+    format: "open",
+    description:
+      "An open-ended question asking the player to identify a recurring theme or trend across episodes.",
+  },
+  prediction: {
+    format: "open",
+    description:
+      "An open-ended question asking the player to make a prediction based on the episode content.",
+  },
+  connect_the_dots: {
+    format: "open",
+    description:
+      "An open-ended question asking what two episodes have in common or how their ideas relate.",
+  },
+};
+
+function buildPrompt(
+  type: QuestionType,
+  episode: Episode,
+  secondEpisode?: Episode,
+): string {
+  const config = QUESTION_TYPE_CONFIG[type];
+  const episodeContext = formatEpisode(episode);
+
+  let context = `## Episode\n${episodeContext}`;
+  if (secondEpisode && type === "connect_the_dots") {
+    context += `\n\n## Second Episode\n${formatEpisode(secondEpisode)}`;
+  }
+
+  const formatInstructions =
+    config.format === "multiple_choice"
+      ? `Respond in JSON:
+{
+  "text": "the question text",
+  "options": ["A) ...", "B) ...", "C) ...", "D) ..."],
+  "correct_answer": "A",
+  "source_quote": "the part of the episode that supports the answer"
+}`
+      : `Respond in JSON:
+{
+  "text": "the question text",
+  "model_answer": "an ideal answer in 2-3 sentences",
+  "scoring_rubric": "key points the answer should cover, as a comma-separated list",
+  "source_quote": "the part of the episode that supports the answer"
+}`;
+
+  return `You are a quiz question writer for a podcast knowledge game.
+
+${context}
+
+## Task
+${config.description}
+
+The question MUST be answerable from the episode content provided. Do not ask about information not present in the summaries, quotes, or takeaways.
+
+${formatInstructions}
+
+Return ONLY the JSON object, no other text.`;
+}
+
+function formatEpisode(ep: Episode): string {
+  return `Title: ${ep.title}
+Podcast: ${ep.podcast}
+Topics: ${ep.key_topics.join(", ")}
+Quotes: ${ep.quotes.map((q) => `"${q}"`).join("; ")}
+Key Takeaways: ${ep.key_takeaways.join("; ")}
+Summary: ${ep.full_summary}`;
+}
+
+export async function generateQuestion(
+  episode: Episode,
+  type: QuestionType,
+  secondEpisode?: Episode,
+): Promise<GeneratedQuestion> {
+  const config = QUESTION_TYPE_CONFIG[type];
+  const prompt = buildPrompt(type, episode, secondEpisode);
+
+  const response = await anthropic.messages.create({
+    model: "claude-sonnet-4-6-20250514",
+    max_tokens: 1024,
+    messages: [{ role: "user", content: prompt }],
+  });
+
+  const text =
+    response.content[0].type === "text" ? response.content[0].text : "";
+
+  // Extract JSON from response (handle markdown code blocks)
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error(`Failed to parse question JSON from response: ${text}`);
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]);
+
+  return {
+    type,
+    format: config.format,
+    text: parsed.text,
+    options: parsed.options ?? null,
+    correct_answer:
+      config.format === "multiple_choice"
+        ? parsed.correct_answer
+        : parsed.model_answer,
+    model_answer: parsed.model_answer ?? null,
+    scoring_rubric: parsed.scoring_rubric ?? null,
+    topic: episode.key_topics[0],
+    source_quote: parsed.source_quote ?? null,
+    episode_id: episode.id,
+    second_episode_id: secondEpisode?.id ?? null,
+  };
+}
+
+export async function generateQuestionsForEpisode(
+  episode: Episode,
+  types: QuestionType[] = ["factual_recall", "speaker_attribution"],
+  secondEpisode?: Episode,
+): Promise<GeneratedQuestion[]> {
+  const questions: GeneratedQuestion[] = [];
+
+  for (const type of types) {
+    const q = await generateQuestion(episode, type, secondEpisode);
+    questions.push(q);
+  }
+
+  return questions;
 }

--- a/scripts/generate-questions.ts
+++ b/scripts/generate-questions.ts
@@ -1,0 +1,170 @@
+/**
+ * Generate questions from episodes using Claude and insert into Supabase.
+ *
+ * Usage:
+ *   NEXT_PUBLIC_SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... ANTHROPIC_API_KEY=... \
+ *     bun run scripts/generate-questions.ts [--limit N] [--types type1,type2]
+ *
+ * Generates ~5 questions per episode (one per type) for top episodes per topic.
+ * With 20 topics x ~10 episodes = ~200 episodes x 1-2 MC types = 100+ questions minimum.
+ */
+
+import { createClient } from "@supabase/supabase-js";
+import {
+  generateQuestion,
+  type QuestionType,
+  type GeneratedQuestion,
+} from "../lib/generator";
+import type { Episode } from "../lib/corpus";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+
+if (!supabaseUrl || !serviceRoleKey || !process.env.ANTHROPIC_API_KEY) {
+  console.error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, or ANTHROPIC_API_KEY",
+  );
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+// Parse CLI args
+const args = process.argv.slice(2);
+const limitIdx = args.indexOf("--limit");
+const episodeLimit = limitIdx !== -1 ? parseInt(args[limitIdx + 1]) : 50;
+const typesIdx = args.indexOf("--types");
+const requestedTypes: QuestionType[] = typesIdx !== -1
+  ? (args[typesIdx + 1].split(",") as QuestionType[])
+  : ["factual_recall", "speaker_attribution"];
+
+// For open question types, we process fewer episodes (they're more expensive)
+const OPEN_TYPES: QuestionType[] = [
+  "trend_identification",
+  "prediction",
+  "connect_the_dots",
+];
+
+async function fetchEpisodes(limit: number): Promise<Episode[]> {
+  const { data, error } = await supabase
+    .from("episodes")
+    .select("*")
+    .order("published_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error("Failed to fetch episodes:", error.message);
+    process.exit(1);
+  }
+  return data ?? [];
+}
+
+async function insertQuestion(q: GeneratedQuestion) {
+  const { error } = await supabase.from("questions").insert({
+    episode_id: q.episode_id,
+    second_episode_id: q.second_episode_id,
+    type: q.type,
+    format: q.format,
+    text: q.text,
+    options: q.options,
+    correct_answer: q.correct_answer,
+    model_answer: q.model_answer,
+    scoring_rubric: q.scoring_rubric,
+    topic: q.topic,
+    source_quote: q.source_quote,
+  });
+
+  if (error) {
+    console.error(`  Failed to insert question: ${error.message}`);
+    return false;
+  }
+  return true;
+}
+
+async function main() {
+  console.log(
+    `Generating questions (limit=${episodeLimit}, types=${requestedTypes.join(",")})`,
+  );
+
+  const episodes = await fetchEpisodes(episodeLimit);
+  console.log(`Fetched ${episodes.length} episodes\n`);
+
+  let generated = 0;
+  let failed = 0;
+
+  for (let i = 0; i < episodes.length; i++) {
+    const episode = episodes[i];
+    console.log(
+      `[${i + 1}/${episodes.length}] "${episode.title}" (${episode.key_topics[0]})`,
+    );
+
+    for (const type of requestedTypes) {
+      // For connect_the_dots, pick a random second episode
+      let secondEpisode: Episode | undefined;
+      if (type === "connect_the_dots") {
+        const others = episodes.filter((e) => e.id !== episode.id);
+        secondEpisode = others[Math.floor(Math.random() * others.length)];
+      }
+
+      try {
+        const question = await generateQuestion(
+          episode,
+          type,
+          secondEpisode,
+        );
+
+        // Quality gate: reject if source_quote is missing
+        if (!question.source_quote) {
+          console.log(`  SKIP ${type}: no source quote (not traceable)`);
+          failed++;
+          continue;
+        }
+
+        const ok = await insertQuestion(question);
+        if (ok) {
+          generated++;
+          console.log(`  OK ${type}: "${question.text.slice(0, 60)}..."`);
+        } else {
+          failed++;
+        }
+      } catch (err) {
+        console.error(
+          `  FAIL ${type}: ${err instanceof Error ? err.message : err}`,
+        );
+        failed++;
+      }
+
+      // Rate limiting: small delay between API calls
+      await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+
+  console.log(`\nDone! Generated: ${generated}, Failed: ${failed}`);
+
+  // Print distribution
+  const { data: counts } = await supabase
+    .from("questions")
+    .select("type, topic");
+
+  if (counts) {
+    const byType: Record<string, number> = {};
+    const byTopic: Record<string, number> = {};
+    for (const row of counts) {
+      byType[row.type] = (byType[row.type] || 0) + 1;
+      byTopic[row.topic] = (byTopic[row.topic] || 0) + 1;
+    }
+
+    console.log("\nBy type:");
+    for (const [t, c] of Object.entries(byType).sort((a, b) => b[1] - a[1])) {
+      console.log(`  ${t}: ${c}`);
+    }
+    console.log("\nBy topic (top 10):");
+    for (const [t, c] of Object.entries(byTopic)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 10)) {
+      console.log(`  ${t}: ${c}`);
+    }
+  }
+}
+
+main();

--- a/supabase/migrations/002_create_questions.sql
+++ b/supabase/migrations/002_create_questions.sql
@@ -1,0 +1,36 @@
+-- Questions table for generated quiz questions
+create type question_type as enum (
+  'factual_recall',
+  'speaker_attribution',
+  'trend_identification',
+  'prediction',
+  'connect_the_dots'
+);
+
+create type question_format as enum ('multiple_choice', 'open');
+
+create table if not exists questions (
+  id uuid primary key default gen_random_uuid(),
+  episode_id uuid references episodes(id) on delete cascade,
+  second_episode_id uuid references episodes(id) on delete set null,
+  type question_type not null,
+  format question_format not null,
+  text text not null,
+  options text[] default null,
+  correct_answer text not null,
+  model_answer text,
+  scoring_rubric text,
+  topic text not null,
+  source_quote text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_questions_topic on questions (topic);
+create index if not exists idx_questions_type on questions (type);
+create index if not exists idx_questions_episode on questions (episode_id);
+
+alter table questions enable row level security;
+
+create policy "Questions are publicly readable"
+  on questions for select
+  using (true);


### PR DESCRIPTION
## Summary
- Question generator using Claude claude-sonnet-4-6 with 5 question types:
  - **Factual recall** (MC): specific details from episodes
  - **Speaker attribution** (MC): which podcast/episode said what
  - **Trend identification** (open): recurring themes across episodes
  - **Prediction** (open): forecasting based on episode content
  - **Connect-the-dots** (open): relationships between two episodes
- MC questions get 4 options; open questions get model answer + scoring rubric
- Quality gate rejects questions without traceable source quotes
- Supabase `questions` table with enum types and topic/type indexes
- CLI generation script with rate limiting and progress logging

## Setup
1. Run migration: `supabase/migrations/002_create_questions.sql`
2. Generate: `ANTHROPIC_API_KEY=... SUPABASE_SERVICE_ROLE_KEY=... bun run scripts/generate-questions.ts`

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `bun run build` succeeds
- [ ] Generation script produces questions with valid JSON structure
- [ ] Quality gate rejects questions without source quotes

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)