### PR TITLE
Build game loop: topic selection -> questions -> results

### DIFF
--- a/app/api/evaluate/route.ts
+++ b/app/api/evaluate/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { evaluateAnswer } from "@/lib/evaluator";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const { questionId, playerAnswer } = body;
+
+  if (!questionId || playerAnswer === undefined) {
+    return NextResponse.json(
+      { error: "questionId and playerAnswer are required" },
+      { status: 400 },
+    );
+  }
+
+  // Fetch the full question with answer data
+  const { data: question, error } = await supabase
+    .from("questions")
+    .select("*")
+    .eq("id", questionId)
+    .single();
+
+  if (error || !question) {
+    return NextResponse.json(
+      { error: "Question not found" },
+      { status: 404 },
+    );
+  }
+
+  const result = await evaluateAnswer(
+    {
+      format: question.format,
+      text: question.text,
+      options: question.options,
+      correct_answer: question.correct_answer,
+      model_answer: question.model_answer,
+      scoring_rubric: question.scoring_rubric,
+    },
+    playerAnswer,
+  );
+
+  return NextResponse.json({
+    score: result.score,
+    feedback: result.feedback,
+    correctAnswer: result.correctAnswer,
+    sourceQuote: question.source_quote,
+  });
+}

--- a/app/api/questions/route.ts
+++ b/app/api/questions/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const topic = searchParams.get("topic");
+  const count = Math.min(parseInt(searchParams.get("count") ?? "5"), 20);
+
+  if (!topic) {
+    return NextResponse.json({ error: "topic is required" }, { status: 400 });
+  }
+
+  // Map landing-page slugs to corpus topics
+  const TOPIC_MAPPING: Record<string, string[]> = {
+    growth: ["growth", "startups"],
+    product: ["product-management", "design"],
+    leadership: ["leadership", "engineering-culture"],
+    strategy: ["strategy", "fintech"],
+    engineering: [
+      "infrastructure",
+      "cloud-native",
+      "platform-engineering",
+      "developer-tools",
+      "data-engineering",
+    ],
+  };
+
+  let query = supabase
+    .from("questions")
+    .select(
+      "id, type, format, text, options, topic, episode_id, second_episode_id",
+    );
+
+  if (topic !== "random") {
+    const corpusTopics = TOPIC_MAPPING[topic] ?? [topic];
+    query = query.in("topic", corpusTopics);
+  }
+
+  const { data, error } = await query.limit(count * 3); // fetch extra to randomize
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Shuffle and take the requested count
+  const shuffled = (data ?? []).sort(() => Math.random() - 0.5).slice(0, count);
+
+  // Fetch episode titles for context
+  const episodeIds = [
+    ...new Set(
+      shuffled
+        .flatMap((q) => [q.episode_id, q.second_episode_id])
+        .filter(Boolean),
+    ),
+  ];
+
+  const { data: episodes } = await supabase
+    .from("episodes")
+    .select("id, title, podcast, key_topics, quotes, key_takeaways")
+    .in("id", episodeIds);
+
+  const episodeMap = new Map(
+    (episodes ?? []).map((ep) => [ep.id, ep]),
+  );
+
+  const questions = shuffled.map((q) => ({
+    ...q,
+    episode: episodeMap.get(q.episode_id) ?? null,
+    secondEpisode: q.second_episode_id
+      ? episodeMap.get(q.second_episode_id) ?? null
+      : null,
+  }));
+
+  return NextResponse.json({ questions });
+}

--- a/app/game/[topic]/game-client.tsx
+++ b/app/game/[topic]/game-client.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+
+interface EpisodeContext {
+  id: string;
+  title: string;
+  podcast: string;
+  key_topics: string[];
+  quotes: string[];
+  key_takeaways: string[];
+}
+
+interface Question {
+  id: string;
+  type: string;
+  format: "multiple_choice" | "open";
+  text: string;
+  options: string[] | null;
+  topic: string;
+  episode: EpisodeContext | null;
+  secondEpisode: EpisodeContext | null;
+}
+
+interface FeedbackData {
+  score: number;
+  feedback: string;
+  correctAnswer: string;
+  sourceQuote: string | null;
+}
+
+interface AnswerRecord {
+  questionId: string;
+  questionText: string;
+  questionType: string;
+  playerAnswer: string;
+  score: number;
+  feedback: string;
+  correctAnswer: string;
+  episodeTitle: string;
+}
+
+type GamePhase = "setup" | "loading" | "playing" | "feedback" | "finished";
+
+export default function GameClient({ topic }: { topic: string }) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<GamePhase>("setup");
+  const [questionCount, setQuestionCount] = useState(5);
+  const [questions, setQuestions] = useState<Question[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [openAnswer, setOpenAnswer] = useState("");
+  const [feedbackData, setFeedbackData] = useState<FeedbackData | null>(null);
+  const [answers, setAnswers] = useState<AnswerRecord[]>([]);
+  const [evaluating, setEvaluating] = useState(false);
+
+  const currentQuestion = questions[currentIndex] ?? null;
+
+  const startGame = useCallback(async () => {
+    setPhase("loading");
+    try {
+      const res = await fetch(
+        `/api/questions?topic=${topic}&count=${questionCount}`,
+      );
+      const data = await res.json();
+      if (!data.questions?.length) {
+        alert("No questions available for this topic yet. Try another topic.");
+        setPhase("setup");
+        return;
+      }
+      setQuestions(data.questions);
+      setCurrentIndex(0);
+      setAnswers([]);
+      setPhase("playing");
+    } catch {
+      alert("Failed to load questions. Please try again.");
+      setPhase("setup");
+    }
+  }, [topic, questionCount]);
+
+  const submitAnswer = useCallback(async () => {
+    if (!currentQuestion) return;
+
+    const playerAnswer =
+      currentQuestion.format === "multiple_choice"
+        ? selectedOption ?? ""
+        : openAnswer;
+
+    if (!playerAnswer.trim()) return;
+
+    setEvaluating(true);
+    try {
+      const res = await fetch("/api/evaluate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          questionId: currentQuestion.id,
+          playerAnswer,
+        }),
+      });
+      const result: FeedbackData = await res.json();
+      setFeedbackData(result);
+
+      setAnswers((prev) => [
+        ...prev,
+        {
+          questionId: currentQuestion.id,
+          questionText: currentQuestion.text,
+          questionType: currentQuestion.type,
+          playerAnswer,
+          score: result.score,
+          feedback: result.feedback,
+          correctAnswer: result.correctAnswer,
+          episodeTitle: currentQuestion.episode?.title ?? "Unknown",
+        },
+      ]);
+
+      setPhase("feedback");
+    } catch {
+      alert("Failed to evaluate answer. Please try again.");
+    } finally {
+      setEvaluating(false);
+    }
+  }, [currentQuestion, selectedOption, openAnswer]);
+
+  const nextQuestion = useCallback(() => {
+    setSelectedOption(null);
+    setOpenAnswer("");
+    setFeedbackData(null);
+
+    if (currentIndex + 1 >= questions.length) {
+      setPhase("finished");
+    } else {
+      setCurrentIndex((i) => i + 1);
+      setPhase("playing");
+    }
+  }, [currentIndex, questions.length]);
+
+  const totalScore = answers.reduce((sum, a) => sum + a.score, 0);
+  const avgScore = answers.length ? Math.round(totalScore / answers.length) : 0;
+
+  // Setup screen
+  if (phase === "setup") {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16">
+        <button
+          onClick={() => router.push("/")}
+          className="mb-8 text-sm text-gray-500 hover:text-gray-300"
+        >
+          &larr; Back to topics
+        </button>
+        <h1 className="mb-2 text-3xl font-bold capitalize">{topic} Quiz</h1>
+        <p className="mb-8 text-gray-400">
+          Choose how many questions you want to tackle.
+        </p>
+
+        <div className="mb-8 flex gap-3">
+          {[5, 10, 20].map((n) => (
+            <button
+              key={n}
+              onClick={() => setQuestionCount(n)}
+              className={`rounded-lg px-6 py-3 text-lg font-semibold transition-colors ${
+                questionCount === n
+                  ? "bg-indigo-600 text-white"
+                  : "border border-gray-700 bg-gray-900 text-gray-300 hover:border-gray-500"
+              }`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+
+        <button
+          onClick={startGame}
+          className="rounded-xl bg-indigo-600 px-8 py-4 text-lg font-semibold text-white transition-colors hover:bg-indigo-500"
+        >
+          Start Quiz
+        </button>
+      </main>
+    );
+  }
+
+  // Loading
+  if (phase === "loading") {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16 text-center">
+        <div className="text-lg text-gray-400">Loading questions...</div>
+      </main>
+    );
+  }
+
+  // Playing — show current question
+  if (phase === "playing" && currentQuestion) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16">
+        {/* Progress bar */}
+        <div className="mb-6 flex items-center justify-between text-sm text-gray-500">
+          <span>
+            Question {currentIndex + 1} of {questions.length}
+          </span>
+          <span className="capitalize">
+            {currentQuestion.type.replace(/_/g, " ")}
+          </span>
+        </div>
+        <div className="mb-8 h-1 rounded-full bg-gray-800">
+          <div
+            className="h-1 rounded-full bg-indigo-500 transition-all"
+            style={{
+              width: `${((currentIndex + 1) / questions.length) * 100}%`,
+            }}
+          />
+        </div>
+
+        {/* Episode context */}
+        {currentQuestion.episode && (
+          <div className="mb-6 rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+            <div className="mb-1 text-xs font-medium uppercase tracking-wider text-gray-500">
+              Source Episode
+            </div>
+            <div className="text-sm font-medium text-gray-300">
+              {currentQuestion.episode.title}
+            </div>
+            <div className="text-xs text-gray-500">
+              {currentQuestion.episode.podcast}
+            </div>
+          </div>
+        )}
+
+        {/* Question */}
+        <h2 className="mb-6 text-xl font-semibold leading-relaxed">
+          {currentQuestion.text}
+        </h2>
+
+        {/* MC options */}
+        {currentQuestion.format === "multiple_choice" &&
+          currentQuestion.options && (
+            <div className="mb-6 space-y-3">
+              {currentQuestion.options.map((option) => {
+                const letter = option.trim().charAt(0);
+                return (
+                  <button
+                    key={option}
+                    onClick={() => setSelectedOption(letter)}
+                    className={`w-full rounded-lg border p-4 text-left transition-colors ${
+                      selectedOption === letter
+                        ? "border-indigo-500 bg-indigo-500/10 text-white"
+                        : "border-gray-700 bg-gray-900 text-gray-300 hover:border-gray-500"
+                    }`}
+                  >
+                    {option}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
+        {/* Open answer */}
+        {currentQuestion.format === "open" && (
+          <textarea
+            value={openAnswer}
+            onChange={(e) => setOpenAnswer(e.target.value)}
+            placeholder="Type your answer..."
+            rows={4}
+            className="mb-6 w-full rounded-lg border border-gray-700 bg-gray-900 p-4 text-gray-100 placeholder-gray-600 focus:border-indigo-500 focus:outline-none"
+          />
+        )}
+
+        <button
+          onClick={submitAnswer}
+          disabled={
+            evaluating ||
+            (currentQuestion.format === "multiple_choice"
+              ? !selectedOption
+              : !openAnswer.trim())
+          }
+          className="rounded-xl bg-indigo-600 px-8 py-3 font-semibold text-white transition-colors hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {evaluating ? "Evaluating..." : "Submit Answer"}
+        </button>
+      </main>
+    );
+  }
+
+  // Feedback
+  if (phase === "feedback" && feedbackData && currentQuestion) {
+    const isCorrect = feedbackData.score >= 70;
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16">
+        {/* Score badge */}
+        <div
+          className={`mb-6 inline-flex items-center gap-2 rounded-full px-4 py-2 text-sm font-semibold ${
+            isCorrect
+              ? "bg-green-500/10 text-green-400"
+              : "bg-red-500/10 text-red-400"
+          }`}
+        >
+          <span className="text-lg">{isCorrect ? "+" : ""}{feedbackData.score}</span>
+          <span>/ 100</span>
+        </div>
+
+        {/* Feedback */}
+        <p className="mb-6 text-lg">{feedbackData.feedback}</p>
+
+        {/* Correct answer */}
+        <div className="mb-4 rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+          <div className="mb-1 text-xs font-medium uppercase tracking-wider text-gray-500">
+            {isCorrect ? "Full Context" : "Correct Answer"}
+          </div>
+          <p className="text-sm text-gray-300">{feedbackData.correctAnswer}</p>
+        </div>
+
+        {/* Source quote */}
+        {feedbackData.sourceQuote && (
+          <div className="mb-6 rounded-lg border border-gray-800 bg-gray-900/50 p-4">
+            <div className="mb-1 text-xs font-medium uppercase tracking-wider text-gray-500">
+              From the Episode
+            </div>
+            <p className="text-sm italic text-gray-400">
+              &ldquo;{feedbackData.sourceQuote}&rdquo;
+            </p>
+            {currentQuestion.episode && (
+              <p className="mt-2 text-xs text-gray-600">
+                &mdash; {currentQuestion.episode.title} ({currentQuestion.episode.podcast})
+              </p>
+            )}
+          </div>
+        )}
+
+        <button
+          onClick={nextQuestion}
+          className="rounded-xl bg-indigo-600 px-8 py-3 font-semibold text-white transition-colors hover:bg-indigo-500"
+        >
+          {currentIndex + 1 >= questions.length
+            ? "See Results"
+            : "Next Question"}
+        </button>
+      </main>
+    );
+  }
+
+  // Finished — results
+  if (phase === "finished") {
+    const byType: Record<string, { total: number; count: number }> = {};
+    for (const a of answers) {
+      if (!byType[a.questionType]) byType[a.questionType] = { total: 0, count: 0 };
+      byType[a.questionType].total += a.score;
+      byType[a.questionType].count += 1;
+    }
+
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-16">
+        <h1 className="mb-2 text-3xl font-bold">Quiz Complete!</h1>
+        <p className="mb-8 text-gray-400 capitalize">{topic} quiz</p>
+
+        {/* Score */}
+        <div className="mb-8 rounded-xl border border-gray-800 bg-gray-900 p-8 text-center">
+          <div className="mb-1 text-5xl font-bold text-indigo-400">
+            {avgScore}
+          </div>
+          <div className="text-sm text-gray-500">
+            Average Score ({answers.length} questions)
+          </div>
+        </div>
+
+        {/* Breakdown by type */}
+        <div className="mb-8">
+          <h2 className="mb-3 text-lg font-semibold">By Question Type</h2>
+          <div className="space-y-2">
+            {Object.entries(byType).map(([type, { total, count }]) => (
+              <div
+                key={type}
+                className="flex items-center justify-between rounded-lg border border-gray-800 bg-gray-900/50 px-4 py-3"
+              >
+                <span className="text-sm capitalize text-gray-300">
+                  {type.replace(/_/g, " ")}
+                </span>
+                <span className="text-sm font-semibold text-gray-100">
+                  {Math.round(total / count)} avg ({count})
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* What you learned */}
+        <div className="mb-8">
+          <h2 className="mb-3 text-lg font-semibold">What You Learned</h2>
+          <div className="space-y-2">
+            {answers.map((a, i) => (
+              <div
+                key={i}
+                className={`rounded-lg border p-4 ${
+                  a.score >= 70
+                    ? "border-green-900/50 bg-green-950/20"
+                    : "border-red-900/50 bg-red-950/20"
+                }`}
+              >
+                <div className="mb-1 flex items-center justify-between">
+                  <span className="text-xs text-gray-500">
+                    {a.episodeTitle}
+                  </span>
+                  <span
+                    className={`text-xs font-semibold ${
+                      a.score >= 70 ? "text-green-400" : "text-red-400"
+                    }`}
+                  >
+                    {a.score}/100
+                  </span>
+                </div>
+                <p className="mb-1 text-sm text-gray-300">{a.questionText}</p>
+                <p className="text-xs text-gray-500">{a.feedback}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-3">
+          <button
+            onClick={() => {
+              setPhase("setup");
+              setQuestions([]);
+              setAnswers([]);
+              setCurrentIndex(0);
+            }}
+            className="rounded-xl bg-indigo-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-indigo-500"
+          >
+            Play Again
+          </button>
+          <button
+            onClick={() => router.push("/")}
+            className="rounded-xl border border-gray-700 px-6 py-3 font-semibold text-gray-300 transition-colors hover:border-gray-500"
+          >
+            Pick Another Topic
+          </button>
+        </div>
+      </main>
+    );
+  }
+
+  return null;
+}

--- a/app/game/[topic]/page.tsx
+++ b/app/game/[topic]/page.tsx
@@ -1,3 +1,5 @@
+import GameClient from "./game-client";
+
 interface GamePageProps {
   params: Promise<{ topic: string }>;
 }
@@ -5,12 +7,5 @@ interface GamePageProps {
 export default async function GamePage({ params }: GamePageProps) {
   const { topic } = await params;
 
-  return (
-    <main className="mx-auto max-w-2xl px-4 py-16">
-      <h1 className="mb-4 text-3xl font-bold capitalize">{topic} Quiz</h1>
-      <p className="text-gray-400">
-        Quiz session for <span className="font-semibold text-white">{topic}</span> coming soon.
-      </p>
-    </main>
-  );
+  return <GameClient topic={topic} />;
 }

--- a/app/results/page.tsx
+++ b/app/results/page.tsx
@@ -1,10 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
 export default function ResultsPage() {
+  const router = useRouter();
+
   return (
-    <main className="mx-auto max-w-2xl px-4 py-16">
-      <h1 className="mb-4 text-3xl font-bold">Results</h1>
-      <p className="text-gray-400">
-        Your score and learning summary will appear here.
+    <main className="mx-auto max-w-2xl px-4 py-16 text-center">
+      <h1 className="mb-4 text-3xl font-bold">No Results Yet</h1>
+      <p className="mb-8 text-gray-400">
+        Complete a quiz to see your results here.
       </p>
+      <button
+        onClick={() => router.push("/")}
+        className="rounded-xl bg-indigo-600 px-6 py-3 font-semibold text-white transition-colors hover:bg-indigo-500"
+      >
+        Pick a Topic
+      </button>
     </main>
   );
 }

--- a/lib/anthropic.ts
+++ b/lib/anthropic.ts
@@ -1,9 +1,14 @@
 import Anthropic from "@anthropic-ai/sdk";
 
-const apiKey = process.env.ANTHROPIC_API_KEY;
+let _anthropic: Anthropic | null = null;
 
-if (!apiKey) {
-  console.warn("ANTHROPIC_API_KEY not set — AI features will not work");
+export function getAnthropic(): Anthropic {
+  if (!_anthropic) {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error("ANTHROPIC_API_KEY is not set");
+    }
+    _anthropic = new Anthropic({ apiKey });
+  }
+  return _anthropic;
 }
-
-export const anthropic = new Anthropic({ apiKey: apiKey ?? "" });

--- a/lib/evaluator.ts
+++ b/lib/evaluator.ts
@@ -1,4 +1,4 @@
-import { anthropic } from "./anthropic";
+import { getAnthropic } from "./anthropic";
 
 export interface EvaluationResult {
   score: number;
@@ -73,7 +73,7 @@ Respond in JSON only:
   "feedback": "<one sentence of constructive feedback>"
 }`;
 
-  const response = await anthropic.messages.create({
+  const response = await getAnthropic().messages.create({
     model: "claude-haiku-4-5-20241022",
     max_tokens: 256,
     messages: [{ role: "user", content: prompt }],

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -1,4 +1,4 @@
-import { anthropic } from "./anthropic";
+import { getAnthropic } from "./anthropic";
 import type { Episode } from "./corpus";
 
 export type QuestionType =
@@ -116,7 +116,7 @@ export async function generateQuestion(
   const config = QUESTION_TYPE_CONFIG[type];
   const prompt = buildPrompt(type, episode, secondEpisode);
 
-  const response = await anthropic.messages.create({
+  const response = await getAnthropic().messages.create({
     model: "claude-sonnet-4-6-20250514",
     max_tokens: 1024,
     messages: [{ role: "user", content: prompt }],

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,20 @@
-import { createClient } from "@supabase/supabase-js";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+let _supabase: SupabaseClient | null = null;
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export const supabase = new Proxy({} as SupabaseClient, {
+  get(_target, prop) {
+    if (!_supabase) {
+      const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+      const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+      if (!url || !key) {
+        throw new Error(
+          "NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set",
+        );
+      }
+      _supabase = createClient(url, key);
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (_supabase as any)[prop as string];
+  },
+});


### PR DESCRIPTION
## Summary
Full game loop from topic selection through quiz play to results:

- **Setup screen**: pick question count (5/10/20), then start
- **Question screen**: MC options or open text input, progress bar, episode context
- **Feedback screen**: score badge (green/red), feedback, correct answer, source quote from episode
- **Results screen**: average score, breakdown by question type, per-question review with learning summary
- **API routes**: `GET /api/questions` (fetch shuffled questions by topic), `POST /api/evaluate` (score answers)
- Lazy-init for Anthropic + Supabase clients (builds without env vars)

## Design decisions
- Results shown inline (not a separate page) to preserve game state
- Source episode shown on every question for learning emphasis
- After wrong answers: shows the actual quote from the transcript
- Play Again and Pick Another Topic buttons on results

## Test plan
- [ ] `bun run build` passes without env vars
- [ ] `npx tsc --noEmit` has no errors
- [ ] Landing page -> topic card -> setup screen -> game loop works end-to-end
- [ ] MC and open question types render correctly
- [ ] Feedback shows score, correct answer, and source quote
- [ ] Results screen shows score breakdown and per-question review

Closes #5

Generated with [Claude Code](https://claude.com/claude-code)